### PR TITLE
Ignore invalid function codes sent to other servers

### DIFF
--- a/nanomodbus.c
+++ b/nanomodbus.c
@@ -1878,7 +1878,8 @@ static nmbs_error handle_req_fc(nmbs_t* nmbs) {
 #endif
         default:
             flush(nmbs);
-            err = send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_FUNCTION);
+            if (!nmbs->msg.ignored && !nmbs->msg.broadcast)
+                err = send_exception_msg(nmbs, NMBS_EXCEPTION_ILLEGAL_FUNCTION);
     }
 
     return err;


### PR DESCRIPTION
Currently, when a Modbus master uses an unsupported function code, an exception is sent regardless of whether the request was targeting to the unit ID of the nanoMODBUS server. If a different device was targeted, the exception message interferes with the expected response. With Modbus RTU it is common to have different types of devices with different (and possibly custom) sets of function codes connected to the same bus. This change ensures the exception message is only sent when the nanoMODBUS server was explicitly targeted.